### PR TITLE
Adds secretsFilePathPrefix as a custom option for secrets files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ EMAIL_SERVICE_API_KEY: DEV_API_EXAMPLE_KEY_12
 SESSION_KEY: DEV_SESSION_EXAMPLE_KEY_12
 ```
 
+You can also provide a path prefix if you like to keep your secrets in a different directory e.g.
+```yml
+custom:
+  secretsFilePathPrefix: config
+```
+
 Encrypt the secrets file for the desired stage by running
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class ServerlessPlugin {
       const credentialFileName = `secrets.${this.options.stage}.yml`;
       const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
       const secretsPath = path.join(servicePath, customPath, credentialFileName);
-      const encryptedCredentialsPath = path.join(servicePath, encryptedCredentialFileName);
+      const encryptedCredentialsPath = path.join(servicePath, customPath, encryptedCredentialFileName);
 
       fs.createReadStream(secretsPath)
         .on('error', reject)
@@ -83,7 +83,7 @@ class ServerlessPlugin {
       const credentialFileName = `secrets.${this.options.stage}.yml`;
       const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
       const secretsPath = path.join(servicePath, customPath, credentialFileName);
-      const encryptedCredentialsPath = path.join(servicePath, encryptedCredentialFileName);
+      const encryptedCredentialsPath = path.join(servicePath, customPath, encryptedCredentialFileName);
 
       fs.createReadStream(encryptedCredentialsPath)
         .on('error', reject)
@@ -103,7 +103,7 @@ class ServerlessPlugin {
       const servicePath = this.serverless.config.servicePath;
       const customPath = this.customPath;
       const credentialFileName = `secrets.${this.options.stage}.yml`;
-      const secretsPath = path.join(servicePath, customPath, credentialFileName);
+      const secretsPath = path.join(servicePath, customPath, customPath, credentialFileName);
       fs.access(secretsPath, fs.F_OK, (err) => {
         if (err) {
           reject(`Couldn't find the secrets file for this stage: ${credentialFileName}`);

--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ class ServerlessPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
+    if (this.serverless.service.custom && this.serverless.service.custom.secretsFilePathPrefix) {
+      this.customPath = this.serverless.service.custom.secretsFilePathPrefix;
+    } else {
+      this.customPath = '';
+    }
 
     const commandOptions = {
       stage: {
@@ -52,9 +57,10 @@ class ServerlessPlugin {
   encrypt() {
     return new BbPromise((resolve, reject) => {
       const servicePath = this.serverless.config.servicePath;
+      const customPath = this.customPath;
       const credentialFileName = `secrets.${this.options.stage}.yml`;
       const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
-      const secretsPath = path.join(servicePath, credentialFileName);
+      const secretsPath = path.join(servicePath, customPath, credentialFileName);
       const encryptedCredentialsPath = path.join(servicePath, encryptedCredentialFileName);
 
       fs.createReadStream(secretsPath)
@@ -73,9 +79,10 @@ class ServerlessPlugin {
   decrypt() {
     return new BbPromise((resolve, reject) => {
       const servicePath = this.serverless.config.servicePath;
+      const customPath = this.customPath;
       const credentialFileName = `secrets.${this.options.stage}.yml`;
       const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
-      const secretsPath = path.join(servicePath, credentialFileName);
+      const secretsPath = path.join(servicePath, customPath, credentialFileName);
       const encryptedCredentialsPath = path.join(servicePath, encryptedCredentialFileName);
 
       fs.createReadStream(encryptedCredentialsPath)
@@ -94,8 +101,9 @@ class ServerlessPlugin {
   checkFileExists() {
     return new BbPromise((resolve, reject) => {
       const servicePath = this.serverless.config.servicePath;
+      const customPath = this.customPath;
       const credentialFileName = `secrets.${this.options.stage}.yml`;
-      const secretsPath = path.join(servicePath, credentialFileName);
+      const secretsPath = path.join(servicePath, customPath, credentialFileName);
       fs.access(secretsPath, fs.F_OK, (err) => {
         if (err) {
           reject(`Couldn't find the secrets file for this stage: ${credentialFileName}`);

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ class ServerlessPlugin {
       const servicePath = this.serverless.config.servicePath;
       const customPath = this.customPath;
       const credentialFileName = `secrets.${this.options.stage}.yml`;
-      const secretsPath = path.join(servicePath, customPath, customPath, credentialFileName);
+      const secretsPath = path.join(servicePath, customPath, credentialFileName);
       fs.access(secretsPath, fs.F_OK, (err) => {
         if (err) {
           reject(`Couldn't find the secrets file for this stage: ${credentialFileName}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secrets-plugin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Serverless plugin to help managing credentials in encrypted files",
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
I hope this PR is well received. I'm not much of a JS person.

I've been using Serverless and this plugin and enjoying it thoroughly but I find myself wanting to keep secrets in a different directory then the project root. I've added this option to allow for the use of a different path, and if it is missing then it would behave just as normal. I figured I'd share the idea instead of keeping the edits to myself.

Let me know what you think. Thanks.