### PR TITLE
Adds the ability to specify a custom location for your credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# OS-specific cruft
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ In your `serverless.yaml` you can use the file variable syntax to import the sec
 
 Whenever you want to deploy there needs to be the unencrypted version of the secrets file available otherwise the plugin will prevent the deployment.
 
+## Customisation
+
+If you wish to store your credentials outside your project's root, add the following to `serverless.yml`:
+
+```yml
+custom:
+  pluginConfig:
+    secrets:
+      localPath: "./relative/path/to/dir"
+```
+
+e.g. `localPath: "./config/serverless"` would locate your credentials at `./config/serverless/secrets.{stage}.yml`
+
 # Example
 
 You can check out a full example in the Serverless Examples repository: [serverless/examples/aws-node-env-variables-encrypted-in-a-file](https://github.com/serverless/examples/tree/master/aws-node-env-variables-encrypted-in-a-file).

--- a/index.js
+++ b/index.js
@@ -61,12 +61,12 @@ class ServerlessPlugin {
   }
 
   /**
-   * Use a dot-delimited string to access properties of this.serverless.service
+   * Use a dot-delimited string to access properties of this.serverless.service.custom
    * @param key
    * @returns {*}
    */
   getConfig(key) {
-    return this.getNested(key.split('.'), this.serverless.service)
+    return this.getNested(key.split('.'), this.serverless.service.custom)
   }
 
   /**
@@ -77,7 +77,7 @@ class ServerlessPlugin {
     const servicePath = this.serverless.config.servicePath;
     const credentialFileName = `secrets.${this.options.stage}.yml`;
     const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
-    const config = this.getConfig('custom.pluginConfig.secrets')
+    const config = this.getConfig('pluginConfig.secrets')
 
     return {
       secrets:   path.join(servicePath, config.localPath, credentialFileName),
@@ -86,9 +86,9 @@ class ServerlessPlugin {
   }
 
   encrypt() {
-    return new BbPromise((resolve, reject) => {
-      const credentialPaths = this.getCredentialPaths()
+    const credentialPaths = this.getCredentialPaths()
 
+    return new BbPromise((resolve, reject) => {
       fs.createReadStream(credentialPaths.secrets)
         .on('error', reject)
         .pipe(crypto.createCipher(algorithm, this.options.password))
@@ -103,9 +103,9 @@ class ServerlessPlugin {
   }
 
   decrypt() {
-    return new BbPromise((resolve, reject) => {
-      const credentialPaths = this.getCredentialPaths()
+    const credentialPaths = this.getCredentialPaths()
 
+    return new BbPromise((resolve, reject) => {
       fs.createReadStream(credentialPaths.encrypted)
         .on('error', reject)
         .pipe(crypto.createDecipher(algorithm, this.options.password))
@@ -120,9 +120,9 @@ class ServerlessPlugin {
   }
 
   checkFileExists() {
-    return new BbPromise((resolve, reject) => {
-      const credentialPaths = this.getCredentialPaths()
+    const credentialPaths = this.getCredentialPaths()
 
+    return new BbPromise((resolve, reject) => {
       fs.access(credentialPaths.secrets, fs.F_OK, (err) => {
         if (err) {
           reject(`Couldn't find the secrets file for this stage: ${path.basename(credentialPaths.secrets)} (looking in ${path.dirname(credentialPaths.secrets)})`);

--- a/index.js
+++ b/index.js
@@ -49,22 +49,54 @@ class ServerlessPlugin {
     };
   }
 
+  /**
+   * Retrieve a nested value from an object using an array of path values
+   * Return null in the case of a non-existent path
+   * As described at https://medium.com/javascript-inside/safely-accessing-deeply-nested-values-in-javascript-99bf72a0855a
+   * @param p
+   * @param o
+   */
+  getNested (p, o) {
+    return p.reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, o)
+  }
+
+  /**
+   * Use a dot-delimited string to access properties of this.serverless.service
+   * @param key
+   * @returns {*}
+   */
+  getConfig(key) {
+    return this.getNested(key.split('.'), this.serverless.service)
+  }
+
+  /**
+   * Return an object populated with paths to the credentials
+   * @returns {{secrets: string, encrypted: string}}
+   */
+  getCredentialPaths() {
+    const servicePath = this.serverless.config.servicePath;
+    const credentialFileName = `secrets.${this.options.stage}.yml`;
+    const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
+    const config = this.getConfig('custom.pluginConfig.secrets')
+
+    return {
+      secrets:   path.join(servicePath, config.localPath, credentialFileName),
+      encrypted: path.join(servicePath, config.localPath, encryptedCredentialFileName)
+    }
+  }
+
   encrypt() {
     return new BbPromise((resolve, reject) => {
-      const servicePath = this.serverless.config.servicePath;
-      const credentialFileName = `secrets.${this.options.stage}.yml`;
-      const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
-      const secretsPath = path.join(servicePath, credentialFileName);
-      const encryptedCredentialsPath = path.join(servicePath, encryptedCredentialFileName);
+      const credentialPaths = this.getCredentialPaths()
 
-      fs.createReadStream(secretsPath)
+      fs.createReadStream(credentialPaths.secrets)
         .on('error', reject)
         .pipe(crypto.createCipher(algorithm, this.options.password))
         .on('error', reject)
-        .pipe(fs.createWriteStream(encryptedCredentialsPath))
+        .pipe(fs.createWriteStream(credentialPaths.encrypted))
         .on('error', reject)
         .on('close', () => {
-          this.serverless.cli.log(`Sucessfully encrypted '${credentialFileName}' to '${encryptedCredentialFileName}'`);
+          this.serverless.cli.log(`Sucessfully encrypted '${path.basename(credentialPaths.secrets)}' to '${path.basename(credentialPaths.encrypted)}'`);
           resolve();
         });
     });
@@ -72,20 +104,16 @@ class ServerlessPlugin {
 
   decrypt() {
     return new BbPromise((resolve, reject) => {
-      const servicePath = this.serverless.config.servicePath;
-      const credentialFileName = `secrets.${this.options.stage}.yml`;
-      const encryptedCredentialFileName = `${credentialFileName}.encrypted`;
-      const secretsPath = path.join(servicePath, credentialFileName);
-      const encryptedCredentialsPath = path.join(servicePath, encryptedCredentialFileName);
+      const credentialPaths = this.getCredentialPaths()
 
-      fs.createReadStream(encryptedCredentialsPath)
+      fs.createReadStream(credentialPaths.encrypted)
         .on('error', reject)
         .pipe(crypto.createDecipher(algorithm, this.options.password))
         .on('error', reject)
-        .pipe(fs.createWriteStream(secretsPath))
+        .pipe(fs.createWriteStream(credentialPaths.secrets))
         .on('error', reject)
         .on('close', () => {
-          this.serverless.cli.log(`Sucessfully encrypted '${encryptedCredentialFileName}' to '${credentialFileName}'`);
+          this.serverless.cli.log(`Sucessfully decrypted '${path.basename(credentialPaths.encrypted)}' to '${path.basename(credentialPaths.secrets)}'`);
           resolve();
         });
     });
@@ -93,12 +121,11 @@ class ServerlessPlugin {
 
   checkFileExists() {
     return new BbPromise((resolve, reject) => {
-      const servicePath = this.serverless.config.servicePath;
-      const credentialFileName = `secrets.${this.options.stage}.yml`;
-      const secretsPath = path.join(servicePath, credentialFileName);
-      fs.access(secretsPath, fs.F_OK, (err) => {
+      const credentialPaths = this.getCredentialPaths()
+
+      fs.access(credentialPaths.secrets, fs.F_OK, (err) => {
         if (err) {
-          reject(`Couldn't find the secrets file for this stage: ${credentialFileName}`);
+          reject(`Couldn't find the secrets file for this stage: ${path.basename(credentialPaths.secrets)} (looking in ${path.dirname(credentialPaths.secrets)})`);
         } else {
           resolve();
         }


### PR DESCRIPTION
This PR provides a sample pattern for adding extra config for plugins under the `custom` config key:
```yaml
custom:
  pluginConfig:
    secrets: 
      localPath: 'foo/bar'
    pluginName: 
      key1: val
      key2: val
```

It also consolidates the logic for calculating paths to secrets and encrypted files into a single function for the sake of consistency.