### PR TITLE
Rename class

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const BbPromise = require('bluebird');
 
 const algorithm = 'aes-256-cbc';
 
-class ServerlessPlugin {
+class ServerlessSecretsPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
@@ -107,4 +107,4 @@ class ServerlessPlugin {
   }
 }
 
-module.exports = ServerlessPlugin;
+module.exports = ServerlessSecretsPlugin;


### PR DESCRIPTION
Otherwise Serverless produces meaningless messages as:

![screen shot 2017-10-02 at 16 06 02](https://user-images.githubusercontent.com/122434/31081275-a326880a-a78b-11e7-829c-adf44a75c929.png)
