### PR TITLE
Rely on non deprecated hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class ServerlessPlugin {
     this.hooks = {
       'encrypt:encrypt': this.encrypt.bind(this),
       'decrypt:decrypt': this.decrypt.bind(this),
-      'before:deploy:cleanup': this.checkFileExists.bind(this),
+      'package:cleanup': this.checkFileExists.bind(this),
     };
   }
 


### PR DESCRIPTION
Follow Serverless warning message:

__Serverless: WARNING: Plugin ServerlessPlugin uses deprecated hook before:deploy:cleanup, use package:cleanup hook instead__